### PR TITLE
refactor: integrate backend via ipc

### DIFF
--- a/backend/fitadmin-backend/index.js
+++ b/backend/fitadmin-backend/index.js
@@ -1,57 +1,71 @@
-
-const express = require('express');
-const cors = require('cors');
 const sequelize = require('./config/database');
-const memberRoutes = require('./src/members/routes/member.routes');
-const expenseRoutes = require('./src/expenses/routes/expense.routes');
-const swaggerUi = require('swagger-ui-express');
-const swaggerSpec = require('./config/swagger');
-const feeTypeRoutes = require('./src/feeTypes/routes/feeTypes.routes');
-const paymentRoutes = require('./src/payments/routes/payment.routes');
-const assistanceRoutes = require('./src/assistances/routes/assistances.routes');
-const reportRoutes = require('./src/reports/routes/report.routes');
+const memberController = require('./src/members/controller/member.controller');
+const feeTypeController = require('./src/feeTypes/controller/feeType.controller');
+const assistanceController = require('./src/assistances/controller/assistance.controller');
+const paymentController = require('./src/payments/controller/payment.controller');
+const expenseController = require('./src/expenses/controller/expense.controller');
+const reportController = require('./src/reports/controller/report.controller');
+const Assistance = require('./src/assistances/model/Assistance');
 
-const app = express();
-const PORT = 3001; // podés cambiar el puerto si querés
-
-// Middlewares
-app.use(cors());
-app.use(express.json());
-
-// Rutas
-
-// Members
-app.use('/api/members', memberRoutes);
-
-// FeeTypes
-app.use('/api/fee-types', feeTypeRoutes);
-
-// Payments
-app.use('/api/payments', paymentRoutes);
-
-// Assistances
-app.use('/api/assistances', assistanceRoutes);
-
-// Expenses
-app.use('/api/expenses', expenseRoutes);
-
-// Reports
-app.use('/api/reports', reportRoutes);
-
-
-
-
-
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-
-// Sincronizar base de datos y levantar servidor
-sequelize.sync() // usa alter: true para desarrollo (ajusta la tabla automáticamente)
-  .then(() => {
-    console.log('Base de datos sincronizada');
-    app.listen(PORT, () => {
-      console.log(`Servidor corriendo en http://localhost:${PORT}`);
-    });
-  })
-  .catch((error) => {
-    console.error('Error al conectar con la base de datos:', error);
+function invokeController(controller, req = {}) {
+  return new Promise((resolve, reject) => {
+    const res = {
+      status: () => res,
+      json: data => resolve(data),
+      send: data => resolve(data),
+    };
+    Promise.resolve(controller(req, res)).catch(reject);
   });
+}
+
+async function initDatabase() {
+  await sequelize.sync();
+}
+
+module.exports = {
+  initDatabase,
+  members: {
+    register: data => invokeController(memberController.createMember, { body: data }),
+    list: () => invokeController(memberController.getAllMembers),
+    search: query => invokeController(memberController.searchMember, { query: { query } }),
+    update: (id, data) => invokeController(memberController.updateMember, { params: { id }, body: data }),
+    delete: id => invokeController(memberController.deleteMember, { params: { id } }),
+  },
+  feeTypes: {
+    register: data => invokeController(feeTypeController.registerFeeType, { body: data }),
+    list: () => invokeController(feeTypeController.getAllFeeTypes),
+    update: (id, data) => invokeController(feeTypeController.updateFeeType, { params: { id }, body: data }),
+    delete: id => invokeController(feeTypeController.deleteFeeType, { params: { id } }),
+  },
+  assistances: {
+    register: data => invokeController(assistanceController.registerAssistance, { body: data }),
+    list: () => invokeController(assistanceController.getAllAssistances),
+    byMember: id => invokeController(assistanceController.getAssistancesByMember, { params: { memberId: id } }),
+    delete: id => invokeController(assistanceController.deleteAssistance, { params: { id } }),
+    byDate: date => invokeController(assistanceController.getAssistancesByDate, { params: { date } }),
+    update: (id, data) => Assistance.update(data, { where: { id } }),
+    annul: id => Assistance.update({ status: 'ANULADA' }, { where: { id } }),
+  },
+  payments: {
+    list: () => invokeController(paymentController.getAllPayments),
+    register: data => invokeController(paymentController.registerPayment, { body: data }),
+    update: (id, data) => invokeController(paymentController.updatePayment, { params: { id }, body: data }),
+    delete: id => invokeController(paymentController.deletePayment, { params: { id } }),
+    searchMember: query => invokeController(paymentController.searchMemberWithLastPayment, { query: { query } }),
+    search: query => invokeController(paymentController.searchPaymentsByMember, { query: { query } }),
+  },
+  expenses: {
+    register: data => invokeController(expenseController.createExpense, { body: data }),
+    list: () => invokeController(expenseController.getAllExpenses),
+    getById: id => invokeController(expenseController.getExpenseById, { params: { id } }),
+    update: (id, data) => invokeController(expenseController.updateExpense, { params: { id }, body: data }),
+    delete: id => invokeController(expenseController.deleteExpense, { params: { id } }),
+  },
+  reports: {
+    dailyIncome: date => invokeController(reportController.getDailyIncomeByDate, { query: { date } }),
+    monthlyIncomes: year => invokeController(reportController.getMonthlyIncomes, { query: { year } }),
+    monthlyExpenses: year => invokeController(reportController.getMonthlyExpenses, { query: { year } }),
+    annualProfit: () => invokeController(reportController.getAnnualProfit),
+    monthly: year => invokeController(reportController.getMonthlySummary, { query: { year } }),
+  },
+};

--- a/frontend/fit-admin-frontend/src/config/config.js
+++ b/frontend/fit-admin-frontend/src/config/config.js
@@ -1,10 +1,5 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-  baseURL: 'http://localhost:3001', // cambia esto si lo desplegás
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+const apiClient = {
+  invoke: (channel, data) => window.api.invoke(channel, data)
+}
 
 export default apiClient;

--- a/frontend/fit-admin-frontend/src/dashboard/services/dashboardService.js
+++ b/frontend/fit-admin-frontend/src/dashboard/services/dashboardService.js
@@ -1,28 +1,20 @@
 import apiClient from '../../config/config'
 
-const registerMember = async (memberData) => {
-  const response = await apiClient.post('/api/members/register', memberData)
-  return response.data
+const registerMember = (memberData) => {
+  return apiClient.invoke('members:register', memberData)
 }
 
-const getAllMembers = async () => {
-  const response = await apiClient.get('/api/members/getAll')
-  return response.data
+const getAllMembers = () => {
+  return apiClient.invoke('members:list')
 }
 
-const searchMember = async (query) => {
-  const response = await apiClient.get('/api/members/search', {
-    params: { query }
-  })
-  return response.data
+const searchMember = (query) => {
+  return apiClient.invoke('members:search', query)
 }
 
-
- const registerAssistance = async (data) => {
-  const response = await apiClient.post('/api/assistances/register', data)
-  return response.data
+const registerAssistance = (data) => {
+  return apiClient.invoke('assistances:register', data)
 }
-
 
 export default {
   registerMember,

--- a/frontend/fit-admin-frontend/src/features/assistances/services/assistanceService.js
+++ b/frontend/fit-admin-frontend/src/features/assistances/services/assistanceService.js
@@ -1,28 +1,13 @@
 import apiClient from '../../../config/config'
 
 const assistanceService = {
-searchMember: (query) =>
-  apiClient.get('/api/members/search', {
-    params: { query }  
-  }),
-  getHistoryByMemberId: (id) =>
-    apiClient.get(`/api/assistances/getByMember/${id}`),
-
-  registerAssistance: (memberId) =>
-    apiClient.post(`/api/assistances/register`, { memberId }),
-
-  updateAssistance: (id, data) =>
-    apiClient.put(`/api/assistances/${id}`, data),
-
-  deleteAssistance: (id) => apiClient.delete(`/api/assistances/delete/${id}`), 
-
-
-  annulAssistance: (id) =>
-    apiClient.patch(`/api/assistances/${id}/annul`),
-
-
-  getByDate: (date) => apiClient.get(`/api/assistances/by-date/${date}`)
-
+  searchMember: (query) => apiClient.invoke('members:search', query),
+  getHistoryByMemberId: (id) => apiClient.invoke('assistances:byMember', id),
+  registerAssistance: (memberId) => apiClient.invoke('assistances:register', { memberId }),
+  updateAssistance: (id, data) => apiClient.invoke('assistances:update', { id, data }),
+  deleteAssistance: (id) => apiClient.invoke('assistances:delete', id),
+  annulAssistance: (id) => apiClient.invoke('assistances:annul', id),
+  getByDate: (date) => apiClient.invoke('assistances:byDate', date)
 }
 
 export default assistanceService

--- a/frontend/fit-admin-frontend/src/features/expenses/services/expenseService.js
+++ b/frontend/fit-admin-frontend/src/features/expenses/services/expenseService.js
@@ -1,28 +1,23 @@
 import apiClient from '../../../config/config'
 
-const registerExpense = async (expenseData) => {
-  const response = await apiClient.post('/api/expenses/register', expenseData)
-  return response.data
+const registerExpense = (expenseData) => {
+  return apiClient.invoke('expenses:register', expenseData)
 }
 
-const getAllExpenses = async () => {
-  const response = await apiClient.get('/api/expenses/getAll')
-  return response.data
+const getAllExpenses = () => {
+  return apiClient.invoke('expenses:list')
 }
 
-const getExpenseById = async (id) => {
-  const response = await apiClient.get(`/api/expenses/getById/${id}`)
-  return response.data
+const getExpenseById = (id) => {
+  return apiClient.invoke('expenses:getById', id)
 }
 
-const updateExpense = async (id, data) => {
-  const response = await apiClient.put(`/api/expenses/update/${id}`, data)
-  return response.data
+const updateExpense = (id, data) => {
+  return apiClient.invoke('expenses:update', { id, data })
 }
 
-const deleteExpense = async (id) => {
-  const response = await apiClient.delete(`/api/expenses/delete/${id}`)
-  return response.data
+const deleteExpense = (id) => {
+  return apiClient.invoke('expenses:delete', id)
 }
 
 export default {

--- a/frontend/fit-admin-frontend/src/features/fees/services/feeService.js
+++ b/frontend/fit-admin-frontend/src/features/fees/services/feeService.js
@@ -1,21 +1,17 @@
 import apiClient from '../../../config/config'
 
-export const registerFee = async (feeData) => {
-  const response = await apiClient.post('/api/fee-types/register', feeData)
-  return response.data
+export const registerFee = (feeData) => {
+  return apiClient.invoke('feeTypes:register', feeData)
 }
 
-export const getAllFees = async () => {
-  const response = await apiClient.get('/api/fee-types/getAll')
-  return response.data
+export const getAllFees = () => {
+  return apiClient.invoke('feeTypes:list')
 }
 
-export const updateFee = async (id, feeData) => {
-  const response = await apiClient.put(`/api/fee-types/update/${id}`, feeData)
-  return response.data
+export const updateFee = (id, feeData) => {
+  return apiClient.invoke('feeTypes:update', { id, data: feeData })
 }
 
-export const deleteFee = async (id) => {
-  const response = await apiClient.delete(`/api/fee-types/delete/${id}`)
-  return response.data
+export const deleteFee = (id) => {
+  return apiClient.invoke('feeTypes:delete', id)
 }

--- a/frontend/fit-admin-frontend/src/features/finances/services/financeService.js
+++ b/frontend/fit-admin-frontend/src/features/finances/services/financeService.js
@@ -1,28 +1,21 @@
 import apiClient from '../../../config/config'
 
-export const fetchDailyIncome = async (date) => {
-  const res = await apiClient.get(`/api/reports/dailyIncome?date=${date}`)
-  return res.data
+export const fetchDailyIncome = (date) => {
+  return apiClient.invoke('reports:dailyIncome', date)
 }
 
-export const fetchMonthlyIncomes = async (year) => {
-  const res = await apiClient.get(`/api/reports/monthlyIncomes?year=${year}`)
-  return res.data
+export const fetchMonthlyIncomes = (year) => {
+  return apiClient.invoke('reports:monthlyIncomes', year)
 }
 
-export const fetchMonthlyExpenses = async (year) => {
-  const res = await apiClient.get(`/api/reports/monthlyExpenses?year=${year}`)
-  return res.data
+export const fetchMonthlyExpenses = (year) => {
+  return apiClient.invoke('reports:monthlyExpenses', year)
 }
 
-export const fetchAnnualProfit = async () => {
-  const res = await apiClient.get('/api/reports/annualProfit')
-  return res.data
+export const fetchAnnualProfit = () => {
+  return apiClient.invoke('reports:annualProfit')
 }
 
-export const getMonthlyFinanceByYear = async (year) => {
-  const res = await apiClient.get(`api/reports/monthly`, {
-    params: { year }
-  })
-  return res.data // se espera un array [{ month, income, expense }, ...]
+export const getMonthlyFinanceByYear = (year) => {
+  return apiClient.invoke('reports:monthly', year)
 }

--- a/frontend/fit-admin-frontend/src/features/members/services/memberService.js
+++ b/frontend/fit-admin-frontend/src/features/members/services/memberService.js
@@ -1,22 +1,18 @@
 import apiClient from "../../../config/config";
 
-const registerMember = async (memberData) => {
-  const response = await apiClient.post("/api/members/register", memberData);
-  return response.data;
+const registerMember = (memberData) => {
+  return apiClient.invoke("members:register", memberData);
 };
 
-const getAllMembers = async () => {
-  const response = await apiClient.get("/api/members/getAll");
-  return response.data;
+const getAllMembers = () => {
+  return apiClient.invoke("members:list");
 };
 
 const updateMember = (id, data) => {
-  const response = apiClient.put(`/api/members/update/${id}`, data);
-  return response.data;
+  return apiClient.invoke("members:update", { id, data });
 };
 const deleteMember = (id) => {
-  const response = apiClient.delete(`/api/members/delete/${id}`);
-  return response.data;
+  return apiClient.invoke("members:delete", id);
 };
 export default {
   registerMember,

--- a/frontend/fit-admin-frontend/src/features/payments/services/paymentService.js
+++ b/frontend/fit-admin-frontend/src/features/payments/services/paymentService.js
@@ -1,29 +1,26 @@
 import apiClient from '../../../config/config'
 
 export const searchMember = (query) => {
-  return apiClient.get(`/api/payments/searchMember?query=${query}`)
+  return apiClient.invoke('payments:searchMember', query)
 }
 
 export const registerPayment = (data) => {
-  return apiClient.post('/api/payments/register', data)
+  return apiClient.invoke('payments:register', data)
 }
 
-
 export const getAllPayments = () => {
-  return apiClient.get('/api/payments/getAll')
+  return apiClient.invoke('payments:list')
 }
 
 export const deletePayment = (id) => {
-  return apiClient.delete(`/api/payments/delete/${id}`)
+  return apiClient.invoke('payments:delete', id)
 }
 
-export const updatePayment = (id, data) =>{
-return apiClient.put(`/api/payments/update/${id}`, data)
+export const updatePayment = (id, data) => {
+  return apiClient.invoke('payments:update', { id, data })
+}
 
-} 
-
-export const getPaymentsByQuery = async (query) => {
-  const res = await apiClient.get(`/api/payments/search?query=${query}`)
-  return res.data
+export const getPaymentsByQuery = (query) => {
+  return apiClient.invoke('payments:search', query)
 }
   

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder"
+    "build:frontend": "npm --prefix frontend/fit-admin-frontend run build",
+    "build": "npm run build:frontend && electron-builder"
   },
   "build": {
     "appId": "com.tuempresa.fitadmin",
@@ -12,11 +13,11 @@
     "asar": false,
     "files": [
       "main.js",
+      "preload.js",
       "backend/**/*",
       "frontend/dist/**/*",
       "database.sqlite",
-      "icono.ico",
-      "node/**"
+      "icono.ico"
     ],
     "directories": {
       "buildResources": "assets"

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  invoke: (channel, data) => ipcRenderer.invoke(channel, data)
+});


### PR DESCRIPTION
## Summary
- integrate backend modules directly in Electron main process and expose IPC handlers
- switch renderer services to use window.api.invoke instead of HTTP
- remove bundled node runtime and add preload script to build config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898f0fe6614832c8cd82529a20f5c40